### PR TITLE
Fixing inconsistency on type of variables login and motd

### DIFF
--- a/templates/feature-banner.j2
+++ b/templates/feature-banner.j2
@@ -25,7 +25,7 @@
          "vipVariableName":"{{ item["login"]["variableName"] }}"
 {% else %}
          "vipType":"constant",
-         "vipValue": "{{ item["login"] }}"
+         "vipValue": "{{ item["login"]["globalValue"] }}"
 {% endif %}
 {% else %}
          "vipType":"ignore"
@@ -39,7 +39,7 @@
          "vipVariableName":"{{ item["motd"]["variableName"] }}"
 {% else %}
          "vipType":"constant",
-         "vipValue": "{{ item["motd"] }}"
+         "vipValue": "{{ item["motd"]["globalValue"] }}"
 {% endif %}
 {% else %}
          "vipType":"ignore"


### PR DESCRIPTION
With the current implementation the login and motd variables do not have a defined type, for example they can value:

```
          login: 'Hello'
          motd:'World'

```
or 
```
          login:
            variableName: 'banner_login'
          motd:
            variableName: 'banner_motd'
```

With this PR we would have

```
          login:
           globalValue: 'Hello'
          motd:
           globalValue: 'World'
```