### PR TITLE
Device template tasks were using wrong ansible variables for authentication

### DIFF
--- a/tasks/device-template.yml
+++ b/tasks/device-template.yml
@@ -66,18 +66,18 @@
 
 - name: Interact with the vManage to create templates
   vmanage_device_template:
-    user: "admin"
-    host: "{{ansible_host}}:{{ansible_port}}"
-    password: "admin"
+    user: "{{vmanage_user}}"
+    host: "{{vmanage_host}}"
+    password: "{{vmanage_password}}"
     state: present
     aggregate: "{{device_template_list}}"
   when: device_template_list
 
 - name: Interact with the vManage to create templates
   vmanage_device_template:
-    user: "admin"
-    host: "{{ansible_host}}:{{ansible_port}}"
-    password: "admin"
+    user: "{{vmanage_user}}"
+    host: "{{vmanage_host}}"
+    password: "{{vmanage_password}}"
     state: absent
     aggregate: "{{absent_template_list}}"
   when: absent_template_list


### PR DESCRIPTION
With this fix we are changing the way device template tasks leverage ansible variables.