### PR TITLE
Fix broken vmanage_nping

### DIFF
--- a/tasks/ping-test.yml
+++ b/tasks/ping-test.yml
@@ -9,5 +9,5 @@
   failed_when: actual_result != expected_result
   ignore_errors: False
   vars:
-    actual_result: "{{ True if ping_loss < '100' else False }}"
+    actual_result: "{{ True if ping_loss != '100%' else False }}"
     expected_result: "{{ ping_pass }}"

--- a/tasks/ping-vedge.yml
+++ b/tasks/ping-vedge.yml
@@ -6,14 +6,20 @@
     vedge: "{{ ping_vedge }}"
     vpn: "{{ ping_vpn }}"
     count: "{{ ping_count | default(5) }}"
-    rapid: yes
+    rapid: no
   register: nping
   delegate_to: localhost
 
 - set_fact:
     ping_tx: "{{ nping.json.packetsTransmitted }}"
-    ping_rx: "{{ nping.json.packetsReceived }}"
+    # ping_rx: "{{ nping.json.packetsReceived }}"
+    ping_rx: "{{ nping.json.rawOutput | select('search', 'Echo reply') | list | length | default('0') }}"
     ping_loss: "{{ nping.json.lossPercentage }}"
     ping_rtt_min: "{{ nping.json.minRoundTrip }}"
     ping_rtt_max: "{{ nping.json.maxRoundTrip }}"
     ping_rtt_avg: "{{ nping.json.avgRoundTrip }}"
+
+
+- set_fact:
+    ping_loss: "{{ (100 - (100 * (ping_rx|int / ping_tx|int))) | int | string }}%"
+  


### PR DESCRIPTION
Fixes #54 

The old output of vmanage_nping when pinging an unreachable destination would count network or host unreachables as packets received.  This PR changes vmanage_nping to only count "echo Replies" as valid packets received and set ping_rx and loss % accordingly.