### PR TITLE
Update policy methods

### DIFF
--- a/library/vmanage_policy_definition.py
+++ b/library/vmanage_policy_definition.py
@@ -13,14 +13,13 @@ from ansible.module_utils.viptela import viptelaModule, viptela_argument_spec
 
 def run_module():
     # define available arguments/parameters a user can pass to the module
+    # we only support the 'data' type currently, it will be fixed when we migrate to the SDK
     argument_spec = viptela_argument_spec()
     argument_spec.update(state=dict(type='str', choices=['absent', 'present'], default='present'),
                          aggregate=dict(type='list'),
                          name=dict(type='str'),
                          description = dict(type = 'str'),
-                         type = dict(type ='str', required = True, choices= ['cflowd', 'dnssecurity', 'control',
-                                'hubandspoke', 'acl', 'vpnmembershipgroup', 'mesh', 'rewriterule', 'data',
-                                'rewriterule', 'aclv6']),
+                         type = dict(type ='str', required = True, choices= ['data']),
                          sequences = dict(type ='list'),
                          default_action = dict(type ='dict', alias='defaultAction'),
     )

--- a/library/vmanage_policy_definition_facts.py
+++ b/library/vmanage_policy_definition_facts.py
@@ -37,20 +37,17 @@ def run_module():
     # response = viptela.request('/dataservice/template/policy/vsmart')
     # response_json = response.json()
     # vsmart_policies = response_json['data']
-    policy_definitions = {}
+    policy_definitions = []
     policy_list_dict = viptela.get_policy_list_dict('all', key_name='listId')
     for list_type in viptela.POLICY_DEFINITION_TYPES:
         definition_list = viptela.get_policy_definition_list(list_type)
-        definition_detail_list = []
         for definition in definition_list:
             definition_detail = viptela.get_policy_definition(list_type, definition['definitionId'])
             for sequence in definition_detail['sequences']:
                 for entry in sequence['match']['entries']:
                     entry['listName'] = policy_list_dict[entry['ref']]['name']
                     entry['listType'] = policy_list_dict[entry['ref']]['type']
-            definition_detail_list.append(definition_detail)
-        policy_definitions[list_type] = definition_detail_list
-
+            policy_definitions.append(definition_detail)
 
     viptela.result['policy_definitions'] = policy_definitions
 

--- a/library/vmanage_policy_list.py
+++ b/library/vmanage_policy_list.py
@@ -18,9 +18,9 @@ def run_module():
                          aggregate=dict(type='list'),
                          name=dict(type='str'),
                          description = dict(type = 'str'),
-                         type = dict(type ='str', required = True, choices= ['color', 'vpn', 'site', 'app',
+                         type = dict(type ='str', required = False, choices= ['all', 'color', 'vpn', 'site', 'app',
                             'dataprefix', 'prefix', 'aspath', 'class', 'community', 'extcommunity', 'mirror', 'tloc',
-                            'sla', 'policer', 'ipprefixall', 'dataprefixall']),
+                            'sla', 'policer', 'ipprefixall', 'dataprefixall'], default='all'),
                          entries = dict(type ='list'),
                          push=dict(type='bool', default=False),
                          force=dict(type='bool', default=False)


### PR DESCRIPTION
- For `vmanage_policy_definition` we currently only support 'data' type policy definitions, so make it explicit in the allowed types
- For `vmanage_policy_definition_facts` we now treat the policy as a flat list of dictionaries
- For `vmanage_policy_list added an 'all' type which will take the aggregate list